### PR TITLE
Add Docker Compose for API service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- add docker-compose.yml to run FastAPI service on port 8000

## Testing
- `python -m py_compile app/main.py`
- `python - <<'PY'
import yaml, json
with open('docker-compose.yml') as f:
    data = yaml.safe_load(f)
print(json.dumps(data, indent=2))
PY`
- `docker compose config` *(fails: command not found)*
- `pip install docker-compose` *(fails: Cannot connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68986992d07c832f867b2539cdaa34d0